### PR TITLE
Case insensitive check on skipping retweets

### DIFF
--- a/tootbot.py
+++ b/tootbot.py
@@ -73,7 +73,7 @@ for t in reversed(d.entries[0:5]):
                 sys.exit(1)
 
         # t.author is formatted like (@user) for some weird reason
-        if re.sub('[()@]', '', t.author) != twitter:
+        if re.sub('[()@]', '', t.author.lower()) != twitter.lower():
             # skip retweets
             continue
 


### PR DESCRIPTION
A Twitter account renamed itself to the same name but with different capitalization. Making the check insensitive saves from needing to update the cron job.

Apologies for creating this request on github instead of yerbamate.dev, I tried to register there but didn't get an activation email.